### PR TITLE
hostilefork.json => now runs relative to cwd

### DIFF
--- a/rebol/hostilefork.json
+++ b/rebol/hostilefork.json
@@ -41,7 +41,7 @@
         { "long": "strict", "desc": "Only allow `.ws`, `.wsa`, and `.wsw` formats" }
       ],
       "option_parse": "manual",
-      "notes": "File path is relative to whitespace.reb, not PWD"
+      "notes": "Implementation is using a pure usermode PARSE dialect prototype, slowness is to be expected."
     },
     {
       "type": "interpreter",


### PR DESCRIPTION
(meant to open against wspace:corpus, but it opened against hostilefork:corpus)